### PR TITLE
OPT large graph performance issue 5

### DIFF
--- a/src/controllers/download_controller.py
+++ b/src/controllers/download_controller.py
@@ -43,7 +43,7 @@ def cleanup_old_maps():
         None
     """
     
-    maintenance_cashe_size = 250000000 #0.25GB
+    maintenance_cashe_size = 100000000 #0.1GB
     current_time = time()
     for session_id, (_, timestamp) in list(map_html_data.items()):
         if current_time - timestamp > MAX_SECONDS_TIMEOUT_DELETE:

--- a/src/controllers/error_controller.py
+++ b/src/controllers/error_controller.py
@@ -99,7 +99,7 @@ def add_constraints(df):
     Note:
         - The function checks that the DataFrame is not empty.
         - It limits the number of hydrants to 10 or fewer.
-        - It validates the hose length values to be within the range [120, 1500].
+        - It validates the hose length values to be within the range [120, 5000].
         - It checks that each point is not more than 25 kilometers from the previously
           chosen one.
     
@@ -114,8 +114,8 @@ def add_constraints(df):
         # to check validity of the given hose length
         lengths_values = df["hose_length"]
 
-        if not all(120 <= value <= 1500 for value in lengths_values):
-            raise ValueError("hose length is out of the range [120, 1500].")
+        if not all(120 <= value <= 5000 for value in lengths_values):
+            raise ValueError("hose length is out of the range [120, 5000].")
 
         # check that each hydrant is not more than 25km from the previously chosen one
         if not check_distance(df):

--- a/src/range_finder/rangeFinder.py
+++ b/src/range_finder/rangeFinder.py
@@ -876,9 +876,10 @@ class RangeFinder:
 
             # Combine the results into a single GeoDataFrame
             intersections = gpd.GeoDataFrame(pd.concat(intersections, ignore_index=True))
-            geojson = chuck_geojson_constructor(intersections,unique_colors.__next__())
-            # Add the GeoJson object to the map
-            geojson.add_to(mymap)
+            if not intersections.empty: ##  skip if no intersections,
+                geojson = chuck_geojson_constructor(intersections,unique_colors.__next__())
+                # Add the GeoJson object to the map
+                geojson.add_to(mymap)
             
         self.merged_interactive = mymap
 

--- a/src/range_finder/rangeFinder.py
+++ b/src/range_finder/rangeFinder.py
@@ -12,7 +12,6 @@ warnings.filterwarnings("ignore")
 import folium
 from folium import plugins
 import pandas as pd
-import numpy as np
 import matplotlib.pyplot as plt
 import networkx as nx
 import osmnx as ox
@@ -45,41 +44,6 @@ def find_intersection(pair:tuple):
     """Receive a tuple of two graphs, return their intersection"""
     i, j = pair
     return gpd.overlay(i,j, how='intersection')
-
-def get_geometry_only_gdf(gdf):
-    return gdf.drop(columns=gdf.columns.difference(['geometry']))
-
-
-
-def chuck_geojson_constructor(original_gdf,color):
-    
-    num_chunks = 4
-    gdf_chunks = np.array_split(original_gdf, num_chunks)
-    
-    def convert_to_geojson(gdf_chunk):
-        geojson = folium.GeoJson(
-                    get_geometry_only_gdf(gdf_chunk), 
-                    style_function=lambda x, 
-                    color=color: {
-                        'fillColor': color, 
-                        'color': color, 
-                        'weight': 3,
-                        'fillOpacity': 0.5,
-                        'lineOpacity': 0.5
-                        }
-                    )
-        return geojson
-    
-    executor = concurrent.futures.ThreadPoolExecutor(get_num_cores())
-    with executor as executor:
-        geojson_objects = list(executor.map(convert_to_geojson, gdf_chunks))
-
-    combined_geojson = folium.FeatureGroup(name="Combined GeoJson")
-    for geojson in geojson_objects:
-        geojson.add_to(combined_geojson)
-
-    return combined_geojson
-
 
 def get_colors(n):
     """
@@ -837,7 +801,17 @@ class RangeFinder:
         
         for gdf in gdf_list:
             # Create a GeoJson object from the GeoPandas DataFrame
-            geojson = chuck_geojson_constructor(gdf,unique_colors.__next__())
+            geojson = folium.GeoJson(
+                gdf, 
+                style_function=lambda x, 
+                color=unique_colors.__next__(): {
+                    'fillColor': color, 
+                    'color': color, 
+                    'weight': 3,
+                    'fillOpacity': 0.5,
+                    'lineOpacity': 0.5
+                    }
+                )
             # Add the GeoJson object to the map
             geojson.add_to(mymap)
             
@@ -867,7 +841,17 @@ class RangeFinder:
 
             # Combine the results into a single GeoDataFrame
             intersections = gpd.GeoDataFrame(pd.concat(intersections, ignore_index=True))
-            geojson = chuck_geojson_constructor(intersections,unique_colors.__next__())
+            geojson = folium.GeoJson(
+                intersections, 
+                style_function=lambda x, 
+                color=unique_colors.__next__(): {
+                    'fillColor': color, 
+                    'color': color, 
+                    'weight': 3,
+                    'fillOpacity': 0.5,
+                    'lineOpacity': 0.5
+                    }
+                )
             # Add the GeoJson object to the map
             geojson.add_to(mymap)
             

--- a/src/range_finder/rangeFinder.py
+++ b/src/range_finder/rangeFinder.py
@@ -29,7 +29,7 @@ import concurrent.futures
 import geopandas as gpd
 
 # Configure residual file generation
-ox.config(use_cache=False, log_console=True)
+ox.config(use_cache=False, log_console=False)
 
 # Timeout for elevation calculation (and potentially other) APIs.
 MAX_SECONDS_TIMEOUT_ELEVATION = 15

--- a/src/range_finder/rangeFinder.py
+++ b/src/range_finder/rangeFinder.py
@@ -42,17 +42,25 @@ def get_num_cores():
         return 1 
 
 def find_intersection(pair:tuple):
-    """Receive a tuple of two graphs, return their intersection"""
+    """Receive a tuple of two geopandas dataframes, return their intersection"""
     i, j = pair
     return gpd.overlay(i,j, how='intersection')
 
 def get_geometry_only_gdf(gdf):
+    """
+    For a geopandas dataframe with street info, return a gdf with
+    only the geometry (incl lat/long values) but no meta data.
+    This is is used to simplify graph merges and geojson parsing
+    because there will be less redundant data to process.
+    """
     return gdf.drop(columns=gdf.columns.difference(['geometry']))
 
-
-
 def chuck_geojson_constructor(original_gdf,color):
-    
+    """
+        Converts a geopandas dataframe to a folium geojson, 
+        but does so by first splitting the gdf into chunks,
+        then processing them in parallel.
+    """
     num_chunks = 4
     gdf_chunks = np.array_split(original_gdf, num_chunks)
     
@@ -840,7 +848,8 @@ class RangeFinder:
             geojson = chuck_geojson_constructor(gdf,unique_colors.__next__())
             # Add the GeoJson object to the map
             geojson.add_to(mymap)
-            
+        
+        ## Separately color and render intersections between graphs
         if len(gdf_list) > 1:
             gdf_pairs = []
             ## Necessary to avoid expensive object comparisons with unhashable GeoFrames

--- a/src/range_finder/rangeFinder.py
+++ b/src/range_finder/rangeFinder.py
@@ -74,7 +74,7 @@ def chuck_geojson_constructor(original_gdf,color):
     with executor as executor:
         geojson_objects = list(executor.map(convert_to_geojson, gdf_chunks))
 
-    combined_geojson = folium.FeatureGroup(name="Combined GeoJson")
+    combined_geojson = folium.FeatureGroup()
     for geojson in geojson_objects:
         geojson.add_to(combined_geojson)
 

--- a/src/range_finder/tests_range_finder/test_range_finder.py
+++ b/src/range_finder/tests_range_finder/test_range_finder.py
@@ -522,7 +522,7 @@ def test_rangefinder_add_edge_colors():
     # All element types in the interactive map
     all_children_vals = [str(value) for value in list(rf.merged_interactive._children.values())]
     # At this stage, the map should only have a TileLayer and a GeoJson
-    assert len(all_children_vals) == 2
+    assert len(all_children_vals) == 3 #3 because the two overlap
     assert "folium.raster_layers.TileLayer" in all_children_vals[0]
     assert "folium.features.GeoJson" in all_children_vals[1]
 

--- a/src/range_finder/tests_range_finder/test_range_finder.py
+++ b/src/range_finder/tests_range_finder/test_range_finder.py
@@ -521,10 +521,11 @@ def test_rangefinder_add_edge_colors():
             
     # All element types in the interactive map
     all_children_vals = [str(value) for value in list(rf.merged_interactive._children.values())]
-    # At this stage, the map should only have a TileLayer and a GeoJson
+    # At this stage, the map should only have a TileLayer two FeatureGroups fr the two graphs
     assert len(all_children_vals) == 3 #3 because the two overlap
     assert "folium.raster_layers.TileLayer" in all_children_vals[0]
-    assert "folium.features.GeoJson" in all_children_vals[1]
+    assert "folium.map.FeatureGroup" in all_children_vals[1]
+    assert "folium.map.FeatureGroup" in all_children_vals[2]
 
 
 def test_rangefinder_add_markers_to_map():

--- a/src/templates/errors.html
+++ b/src/templates/errors.html
@@ -37,7 +37,8 @@
     <div class="error-container">
         <h1>Oops. Something went wrong!</h1>
         <h2>Go back to try again.</h2>
-        <p>Error details:</p>
+        <p>Large requests may fail. Try shorter/fewer hoses.</p>
+        <h3>Error details:</h3>
         <p>{{ variable }}</p>
         <p hidden="True">{{ stack_trace }}</p>
     </div>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -304,6 +304,28 @@
 
 <!-- JavaScript to create the map -->
 <script>
+
+    // Function to make the button not interactable and set text to 'Loading...'
+    function SetLoadingMessage() {
+        var button = document.getElementById('collectCoordinatesButton');
+        if (button) {
+            button.disabled = true;
+            button.innerText = 'Loading...';
+        }
+    }
+
+    function UnSetLoadingMessage() {
+        var button = document.getElementById('collectCoordinatesButton');
+        if (button) {
+            button.disabled = false;
+            button.innerText = 'Submit';
+        }
+    }
+
+    window.onload = function() {
+        UnSetLoadingMessage();
+    };
+
     var map = L.map('map', {
         zoomControl: false // Disable the default zoom control
     }).setView([48.1351, 11.5820], 12);
@@ -623,7 +645,7 @@
             alert("No points added");
         }
         else {
-
+            SetLoadingMessage();
             // Get a reference to the checkbox element
             var checkbox = document.getElementById('calculate-height');
 
@@ -657,6 +679,7 @@
         // Clear the points dictionary
         points = {};
     }
+        
 </script>
 
 </html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -153,7 +153,7 @@
             </ul>
 
             <h2>Support & Additional Resources</h2>
-            <p>For more information and detailed usage instructions, refer to our <a href="https://github.com/DSSGxMunich/dssgx_fire_hydrant_range_finder">GitHub repository</a>.</p>
+            <p>For more information and detailed usage instructions, refer to our <a href="https://github.com/DSSGxMunich/hydroxplorer-web-app">GitHub repository</a>.</p>
         </div>
     </div>
     

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -147,7 +147,7 @@
 
             <p><strong>Input Values Restriction:</strong></p>
             <ul class="routing-list">
-                <li>Hose length: 120 to 1500 meters.</li>
+                <li>Hose length: 120 to 5000 meters.</li>
                 <li>Max 10 points on the map.</li>
                 <li>Point-to-point distance limit: 20,000 meters.</li>
             </ul>
@@ -477,7 +477,7 @@
 
         var popupContentInput =
     `<div id="popup" class="popup-row">
-        <label for="popupHoseLengthInput">Hose Length [m]: <input type="number" id="popupHoseLengthInput" placeholder="e.g. 120 to 1500"></label>
+        <label for="popupHoseLengthInput">Hose Length [m]: <input type="number" id="popupHoseLengthInput" placeholder="e.g. 120 to 5000"></label>
     </div>
     <div id="popup" class="popup-row" >
         <label for="popupTransportMode">Transport Mode: 

--- a/src/test_input.py
+++ b/src/test_input.py
@@ -135,7 +135,7 @@ def test_hose_length():
     
     exception_raised = exc_info.value
     print(exception_raised)
-    assert str(exception_raised) == "hose length is out of the range [120, 1500]."
+    assert str(exception_raised) == "hose length is out of the range [120, 5000]."
 
 example_4 = """
     {


### PR DESCRIPTION
Performance on large (5km hose lengths) was slow because:
1) making large requests to OSMnx server.
2) large geopandas dataframes parsing the folium.geojson objects *for rendering on HTML) was expensive. 
Also, AWS EC2 instances would become unresponsive when memory used up because multiple large requests stored in the session memory. 

Fixed these issues by introducing several optimisaions:
1) OSMnx calls now parallelised.
2) Parsing geopandas dfs to geojsons is chunked, and the chunks are processed in parallel. 
3) In-memory 1-hour cache of downloadable maps now enforces a (very large: 100MB where a 5km map is <0.1MB) maximum memory size before cleaning the oldest downloads until cache comes down in size. This ensures the downloading feature never causes memory to balloon. Possible future improvement: instead of storing downloadable maps in memory, create a javascript function that knits them on request from the output page - this shifts the work to the client.

